### PR TITLE
fix: escape double quote

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -87,6 +87,8 @@ function wy2tokens(txt: string, assert = defaultAssert()) {
       var is_sin = txt[i] == "」";
       litlvl--;
       if (litlvl == 0) {
+        // escape double quote
+        tok = tok.replace(/"/g, '\\"');
         tokens.push(["lit", `"${tok}"`, i + 1]);
         idt = false;
         tok = "";


### PR DESCRIPTION
Double quote `"` will escape in strings


```
吾有一言曰「「{"名":"李白"}」」
```
Before
```js
var _ans1 = "{"名":"李白"}";
```
After
```js
var _ans1 = "{\"名\":\"李白\"}";
```